### PR TITLE
BUGFIX: fix typo in de/Main.xlf

### DIFF
--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -31,7 +31,7 @@
                 <source>Workspace</source>
                 <target>Workspace</target>
             </trans-unit>
-            <trans-unit id="modal.button.close.caption" xml:space="preserver">
+            <trans-unit id="modal.button.close.caption" xml:space="preserve">
                 <source>Close</source>
                 <target>Schließen</target>
             </trans-unit>


### PR DESCRIPTION
Change preserver to preserve, because preserver is not allowed as `xml:space` value. The XML parser in the translation chain throws an exception when trying to parse the xlf file. 