### PR TITLE
BUGFIX: NodeDataRepository maps NodeType to string for php 8 compatibility

### DIFF
--- a/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Classes/Domain/Repository/NodeDataRepository.php
@@ -5,6 +5,7 @@ namespace PunktDe\EditConflictPrevention\Domain\Repository;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Neos\ContentRepository\Domain\Model\NodeData;
@@ -42,7 +43,15 @@ class NodeDataRepository extends Repository
      */
     public function findChangedSubNodesInOtherWorkspaces(NodeInterface $documentNode, Workspace $userWorkspace): array
     {
-        $contentCollectionNodeTypes = array_merge([$this->nodeTypeManager->getNodeType(self::NODETYPE_CONTENT_COLLECTION)], $this->nodeTypeManager->getSubNodeTypes(self::NODETYPE_CONTENT_COLLECTION));
+        $contentCollectionNodeTypes = \array_map(
+            static function (NodeType $nodeType) {
+                return $nodeType->getName();
+            },
+            array_merge(
+                [ $this->nodeTypeManager->getNodeType(self::NODETYPE_CONTENT_COLLECTION) ],
+                $this->nodeTypeManager->getSubNodeTypes(self::NODETYPE_CONTENT_COLLECTION)
+            )
+        );
 
         $queryBuilder = $this->entityManager->createQueryBuilder();
         $queryBuilder->select('n.path')


### PR DESCRIPTION
This is a fix for issue #12 . The problem described there is not related to NEOS 7.3 but php 8.x because php 8 enforces strict types. Doctrine's `Expr::quoteLiteral()` then needs a string, and not a NodeType with a `__toString()` to work properly.