### PR TITLE
BUGFIX: Don't try to detect changes if no personal workspace is available

### DIFF
--- a/Classes/Domain/ChangedNodesCalculator.php
+++ b/Classes/Domain/ChangedNodesCalculator.php
@@ -188,6 +188,9 @@ class ChangedNodesCalculator
             return $this->changedNodeDataForDocument[(string)$documentNode];
         }
 
+        if ($this->userService->getPersonalWorkspace() === null) {
+            return [];
+        }
         if ($this->documentTypeIsExcluded($documentNode)) {
             return [];
         }


### PR DESCRIPTION
When changing nodes in a cli context (e.g. through an import) there is no personal workspace available